### PR TITLE
Fix map layer exceptions breaking client-side navigation

### DIFF
--- a/src/lib/components/CommandSearch.svelte
+++ b/src/lib/components/CommandSearch.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { base } from "$app/paths";
 	import { ArrowDown, ArrowUp, CornerDownLeft, SearchIcon } from "@lucide/svelte";
 	import * as Command from "$lib/registry/ui/command/index.js";
 	import { Kbd, KbdGroup } from "$lib/registry/ui/kbd/index.js";
@@ -61,7 +62,7 @@
 		{#each docsNavigation as group}
 			<Command.Group heading={group.title}>
 				{#each group.items as item}
-					<Command.LinkItem href={item.href} value={item.title} onclick={closeDialog}>
+					<Command.LinkItem href="{base}{item.href}" value={item.title} onclick={closeDialog}>
 						<item.icon />
 						<span>{item.title}</span>
 					</Command.LinkItem>

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { base } from "$app/paths";
 	import { cn } from "$lib/utils";
 	import Button from "$lib/registry/ui/button/button.svelte";
 
@@ -60,7 +61,7 @@
 			</div>
 		</div>
 		<div class="flex items-center">
-			<Button variant="ghost" size="sm" href="/docs">Documentation</Button>
+			<Button variant="ghost" size="sm" href="{base}/docs">Documentation</Button>
 			<Button
 				variant="ghost"
 				size="sm"

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { base } from "$app/paths";
 	import { Button } from "$lib/registry/ui/button/index";
 	import ArrowRight from "@lucide/svelte/icons/arrow-right";
 	import CopyButton from "$lib/components/CopyButton.svelte";
@@ -62,11 +63,11 @@
 		</div>
 
 		<div class="animate-fade-up mt-8 flex flex-wrap items-center justify-center gap-3 delay-400">
-			<Button size="lg" href="/docs">
+			<Button size="lg" href="{base}/docs">
 				Get Started
 				<ArrowRight class="size-4" />
 			</Button>
-			<Button variant="ghost" size="lg" href="/docs/basic-map" class="text-muted-foreground">
+			<Button variant="ghost" size="lg" href="{base}/docs/basic-map" class="text-muted-foreground">
 				View Components
 			</Button>
 		</div>

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { base } from "$app/paths";
 	import { cn } from "$lib/utils";
 	import MapPin from "@lucide/svelte/icons/map-pin";
 
@@ -9,7 +10,7 @@
 	const { class: className }: Props = $props();
 </script>
 
-<a href="/" class={cn("flex w-fit items-center gap-1.5", className)}>
+<a href="{base}/" class={cn("flex w-fit items-center gap-1.5", className)}>
 	<MapPin class="text-svelte size-4 shrink-0" />
 	<span class="text-lg font-semibold tracking-tight">pantee-cn</span>
 </a>

--- a/src/lib/components/docs/DocSidebar.svelte
+++ b/src/lib/components/docs/DocSidebar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { base } from "$app/paths";
 	import { page } from "$app/state";
 	import { goto } from "$app/navigation";
 
@@ -11,7 +12,7 @@
 
 	const { setOpenMobile } = Sidebar.useSidebar();
 
-	const pathname = $derived(page.url.pathname);
+	const pathname = $derived(page.url.pathname.slice(base.length) || "/");
 </script>
 
 <Sidebar.Root>
@@ -33,7 +34,7 @@
 									class="text-muted-foreground font-medium"
 									onclick={() => {
 										setOpenMobile(false);
-										goto(item.href);
+										goto(base + item.href);
 									}}
 								>
 									<span class="flex items-center gap-2">

--- a/src/lib/components/docs/DocsHeader.svelte
+++ b/src/lib/components/docs/DocsHeader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { base } from "$app/paths";
 	import { page } from "$app/state";
 	import { cn } from "$lib/utils";
 	import * as Breadcrumb from "$lib/registry/ui/breadcrumb";
@@ -11,7 +12,7 @@
 
 	const { class: className }: Props = $props();
 
-	const pathname = $derived(page.url.pathname);
+	const pathname = $derived(page.url.pathname.slice(base.length) || "/");
 
 	const activeItem = $derived.by(() => {
 		for (const group of docsNavigation) {
@@ -46,11 +47,11 @@
 		<Breadcrumb.Root>
 			<Breadcrumb.List>
 				<Breadcrumb.Item>
-					<Breadcrumb.Link href="/docs">Docs</Breadcrumb.Link>
+					<Breadcrumb.Link href="{base}/docs">Docs</Breadcrumb.Link>
 				</Breadcrumb.Item>
 				<Breadcrumb.Separator />
 				<Breadcrumb.Item>
-					<Breadcrumb.Link href={groupHref}>
+					<Breadcrumb.Link href="{base}{groupHref}">
 						{activeItem?.groupTitle ?? "Overview"}
 					</Breadcrumb.Link>
 				</Breadcrumb.Item>

--- a/src/lib/components/docs/DocsLayout.svelte
+++ b/src/lib/components/docs/DocsLayout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { base } from "$app/paths";
 	import { setContext } from "svelte";
 	import DocsToc from "./DocsToc.svelte";
 	import { findNeighbors } from "$lib/docs-navigation";
@@ -78,7 +79,7 @@
 						variant="ghost"
 						size="sm"
 						class="-ml-2 h-auto py-2"
-						href={neighbors.previous.href}
+						href="{base}{neighbors.previous.href}"
 					>
 						<ChevronLeft />
 						{neighbors.previous.title}
@@ -88,7 +89,7 @@
 				{/if}
 
 				{#if neighbors.next}
-					<Button variant="ghost" size="sm" class="-mr-2 h-auto py-2" href={neighbors.next.href}>
+					<Button variant="ghost" size="sm" class="-mr-2 h-auto py-2" href="{base}{neighbors.next.href}">
 						{neighbors.next.title}
 						<ChevronRight />
 					</Button>

--- a/src/lib/components/docs/DocsLink.svelte
+++ b/src/lib/components/docs/DocsLink.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { base } from "$app/paths";
+
 	const {
 		href,
 		external = false,
@@ -8,10 +10,12 @@
 		external?: boolean;
 		children?: import("svelte").Snippet;
 	}>();
+
+	const resolvedHref = $derived(!external && href.startsWith("/") ? base + href : href);
 </script>
 
 <a
-	{href}
+	href={resolvedHref}
 	target={external ? "_blank" : undefined}
 	rel={external ? "noopener noreferrer" : undefined}
 	class="text-foreground font-medium underline underline-offset-4 transition-colors"

--- a/src/lib/components/docs/preview/examples/CustomLayerContent.svelte
+++ b/src/lib/components/docs/preview/examples/CustomLayerContent.svelte
@@ -23,44 +23,52 @@
 		const map = mapCtx?.getMap();
 		if (!map || !mapCtx?.isLoaded()) return;
 
-		// Add source if it doesn't exist
-		if (!map.getSource("parks")) {
-			map.addSource("parks", {
-				type: "geojson",
-				data: geojsonData,
-			});
+		function setupLayers() {
+			// Add source if it doesn't exist
+			if (!map.getSource("parks")) {
+				map.addSource("parks", {
+					type: "geojson",
+					data: geojsonData,
+				});
+			}
+
+			// Add fill layer if it doesn't exist
+			if (!map.getLayer("parks-fill")) {
+				map.addLayer({
+					id: "parks-fill",
+					type: "fill",
+					source: "parks",
+					paint: {
+						"fill-color": "#22c55e",
+						"fill-opacity": 0.4,
+					},
+					layout: {
+						visibility: isLayerVisible ? "visible" : "none",
+					},
+				});
+			}
+
+			// Add outline layer if it doesn't exist
+			if (!map.getLayer("parks-outline")) {
+				map.addLayer({
+					id: "parks-outline",
+					type: "line",
+					source: "parks",
+					paint: {
+						"line-color": "#16a34a",
+						"line-width": 2,
+					},
+					layout: {
+						visibility: isLayerVisible ? "visible" : "none",
+					},
+				});
+			}
 		}
 
-		// Add fill layer if it doesn't exist
-		if (!map.getLayer("parks-fill")) {
-			map.addLayer({
-				id: "parks-fill",
-				type: "fill",
-				source: "parks",
-				paint: {
-					"fill-color": "#22c55e",
-					"fill-opacity": 0.4,
-				},
-				layout: {
-					visibility: isLayerVisible ? "visible" : "none",
-				},
-			});
-		}
-
-		// Add outline layer if it doesn't exist
-		if (!map.getLayer("parks-outline")) {
-			map.addLayer({
-				id: "parks-outline",
-				type: "line",
-				source: "parks",
-				paint: {
-					"line-color": "#16a34a",
-					"line-width": 2,
-				},
-				layout: {
-					visibility: isLayerVisible ? "visible" : "none",
-				},
-			});
+		if (map.isStyleLoaded()) {
+			setupLayers();
+		} else {
+			map.once("style.load", setupLayers);
 		}
 
 		const handleMouseEnter = () => {
@@ -97,8 +105,12 @@
 		if (!map) return;
 
 		const visibility = isLayerVisible ? "none" : "visible";
-		map.setLayoutProperty("parks-fill", "visibility", visibility);
-		map.setLayoutProperty("parks-outline", "visibility", visibility);
+		if (map.getLayer("parks-fill")) {
+			map.setLayoutProperty("parks-fill", "visibility", visibility);
+		}
+		if (map.getLayer("parks-outline")) {
+			map.setLayoutProperty("parks-outline", "visibility", visibility);
+		}
 		isLayerVisible = !isLayerVisible;
 	}
 </script>

--- a/src/lib/components/docs/preview/examples/LayerMarkersContent.svelte
+++ b/src/lib/components/docs/preview/examples/LayerMarkersContent.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { getContext } from "svelte";
+	import MapLibreGL from "maplibre-gl";
+
+	interface Props {
+		pointsData: GeoJSON.FeatureCollection;
+		onselect: (point: {
+			id: number;
+			name: string;
+			category: string;
+			coordinates: [number, number];
+		} | null) => void;
+	}
+
+	let { pointsData, onselect }: Props = $props();
+
+	const mapCtx = getContext<{
+		getMap: () => MapLibreGL.Map | null;
+		isLoaded: () => boolean;
+	}>("map");
+
+	const instanceId = Math.random().toString(36).substring(2, 9);
+	const sourceId = `markers-source-${instanceId}`;
+	const layerId = `markers-layer-${instanceId}`;
+
+	$effect(() => {
+		const map = mapCtx?.getMap();
+		if (!map || !mapCtx?.isLoaded()) return;
+
+		function setup() {
+			if (map.getSource(sourceId)) return;
+
+			map.addSource(sourceId, {
+				type: "geojson",
+				data: pointsData,
+			});
+
+			map.addLayer({
+				id: layerId,
+				type: "circle",
+				source: sourceId,
+				paint: {
+					"circle-radius": 6,
+					"circle-color": "#3b82f6",
+					"circle-stroke-width": 2,
+					"circle-stroke-color": "#ffffff",
+				},
+			});
+		}
+
+		if (map.isStyleLoaded()) {
+			setup();
+		} else {
+			map.once("style.load", setup);
+		}
+
+		const handleClick = (
+			e: MapLibreGL.MapMouseEvent & { features?: MapLibreGL.MapGeoJSONFeature[] }
+		) => {
+			if (!e.features?.length) return;
+
+			const feature = e.features[0];
+			const coords = (feature.geometry as GeoJSON.Point).coordinates as [number, number];
+
+			onselect({
+				id: feature.properties?.id,
+				name: feature.properties?.name,
+				category: feature.properties?.category,
+				coordinates: coords,
+			});
+		};
+
+		const handleMouseEnter = () => {
+			map.getCanvas().style.cursor = "pointer";
+		};
+
+		const handleMouseLeave = () => {
+			map.getCanvas().style.cursor = "";
+		};
+
+		map.on("click", layerId, handleClick);
+		map.on("mouseenter", layerId, handleMouseEnter);
+		map.on("mouseleave", layerId, handleMouseLeave);
+
+		return () => {
+			map.off("click", layerId, handleClick);
+			map.off("mouseenter", layerId, handleMouseEnter);
+			map.off("mouseleave", layerId, handleMouseLeave);
+
+			try {
+				if (map.getLayer(layerId)) map.removeLayer(layerId);
+				if (map.getSource(sourceId)) map.removeSource(sourceId);
+			} catch {
+				// ignore cleanup errors
+			}
+		};
+	});
+</script>

--- a/src/lib/components/docs/preview/examples/LayerMarkersExample.svelte
+++ b/src/lib/components/docs/preview/examples/LayerMarkersExample.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import MapLibreGL from "maplibre-gl";
 	import { Map, MapPopup } from "$lib/components/ui/map";
-	import { getContext } from "svelte";
+	import LayerMarkersContent from "./LayerMarkersContent.svelte";
 
 	// Generate random points around NYC
 	function generateRandomPoints(count: number) {
@@ -42,101 +41,11 @@
 	}
 
 	let selectedPoint: SelectedPoint | null = $state(null);
-
-	// Store cleanup function
-	let layerCleanup: (() => void) | null = null;
-
-	// Setup map layers - called when Map renders its children
-	function setupMapLayers() {
-		const mapCtx = getContext<{
-			getMap: () => MapLibreGL.Map | null;
-			isLoaded: () => boolean;
-		}>("map");
-
-		const instanceId = Math.random().toString(36).substring(2, 9);
-		const sourceId = `markers-source-${instanceId}`;
-		const layerId = `markers-layer-${instanceId}`;
-
-		const map = mapCtx?.getMap();
-		if (!map || !mapCtx?.isLoaded()) return;
-
-		if (map.getSource(sourceId)) return;
-
-		map.addSource(sourceId, {
-			type: "geojson",
-			data: pointsData,
-		});
-
-		map.addLayer({
-			id: layerId,
-			type: "circle",
-			source: sourceId,
-			paint: {
-				"circle-radius": 6,
-				"circle-color": "#3b82f6",
-				"circle-stroke-width": 2,
-				"circle-stroke-color": "#ffffff",
-			},
-		});
-
-		const handleClick = (
-			e: MapLibreGL.MapMouseEvent & { features?: MapLibreGL.MapGeoJSONFeature[] }
-		) => {
-			if (!e.features?.length) return;
-
-			const feature = e.features[0];
-			const coords = (feature.geometry as GeoJSON.Point).coordinates as [number, number];
-
-			selectedPoint = {
-				id: feature.properties?.id,
-				name: feature.properties?.name,
-				category: feature.properties?.category,
-				coordinates: coords,
-			};
-		};
-
-		const handleMouseEnter = () => {
-			map.getCanvas().style.cursor = "pointer";
-		};
-
-		const handleMouseLeave = () => {
-			map.getCanvas().style.cursor = "";
-		};
-
-		map.on("click", layerId, handleClick);
-		map.on("mouseenter", layerId, handleMouseEnter);
-		map.on("mouseleave", layerId, handleMouseLeave);
-
-		// Store cleanup function
-		layerCleanup = () => {
-			map.off("click", layerId, handleClick);
-			map.off("mouseenter", layerId, handleMouseEnter);
-			map.off("mouseleave", layerId, handleMouseLeave);
-
-			try {
-				if (map.getLayer(layerId)) map.removeLayer(layerId);
-				if (map.getSource(sourceId)) map.removeSource(sourceId);
-			} catch {
-				// ignore cleanup errors
-			}
-		};
-	}
-
-	// Cleanup on unmount
-	$effect(() => {
-		return () => {
-			if (layerCleanup) {
-				layerCleanup();
-				layerCleanup = null;
-			}
-		};
-	});
 </script>
 
 <div class="h-[400px] w-full">
 	<Map center={[-73.98, 40.75]} zoom={11}>
-		<!-- Call setup function - this code runs in Map's context where map context is available -->
-		{setupMapLayers()}
+		<LayerMarkersContent {pointsData} onselect={(point) => (selectedPoint = point)} />
 
 		{#if selectedPoint}
 			<MapPopup

--- a/src/routes/docs/advanced-usage/+page.server.ts
+++ b/src/routes/docs/advanced-usage/+page.server.ts
@@ -1,5 +1,5 @@
 import { highlightCode } from "$lib/highlight";
-import { getExampleSource, getExampleSources } from "$lib/examples";
+import { getExampleSources } from "$lib/examples";
 
 export const load = async () => {
 	const advancedUsageSources = getExampleSources(["AdvancedUsageExample", "MapController"]);
@@ -12,8 +12,13 @@ export const load = async () => {
 		customLayerSources.map((file) => highlightCode(file.code, "svelte"))
 	);
 
-	const layerMarkersSource = getExampleSource("LayerMarkersExample");
-	const layerMarkersHighlighted = await highlightCode(layerMarkersSource, "svelte");
+	const layerMarkersSources = getExampleSources([
+		"LayerMarkersExample",
+		"LayerMarkersContent",
+	]);
+	const layerMarkersHighlighted = await Promise.all(
+		layerMarkersSources.map((file) => highlightCode(file.code, "svelte"))
+	);
 
 	return {
 		advancedUsageFiles: advancedUsageSources.map((file, i) => ({
@@ -26,7 +31,10 @@ export const load = async () => {
 			code: file.code,
 			highlightedCode: customLayerHighlighted[i],
 		})),
-		layerMarkersSource,
-		layerMarkersHighlighted,
+		layerMarkersFiles: layerMarkersSources.map((file, i) => ({
+			name: `${file.name}.svelte`,
+			code: file.code,
+			highlightedCode: layerMarkersHighlighted[i],
+		})),
 	};
 };

--- a/src/routes/docs/advanced-usage/+page.svelte
+++ b/src/routes/docs/advanced-usage/+page.svelte
@@ -13,8 +13,7 @@
 
 	const advancedUsageFiles = $derived(page.data.advancedUsageFiles);
 	const customLayerFiles = $derived(page.data.customLayerFiles);
-	const layerMarkersSource = $derived(page.data.layerMarkersSource);
-	const layerMarkersHighlighted = $derived(page.data.layerMarkersHighlighted);
+	const layerMarkersFiles = $derived(page.data.layerMarkersFiles);
 
 	const useContextCode = `<script lang="ts">
 	import { Map } from "$lib/components/ui/map";
@@ -119,7 +118,7 @@
 		</p>
 	</DocsSection>
 
-	<ComponentPreview code={layerMarkersSource} highlightedCode={layerMarkersHighlighted}>
+	<ComponentPreview files={layerMarkersFiles}>
 		<LayerMarkersExample />
 	</ComponentPreview>
 


### PR DESCRIPTION
## Summary
- Unhandled MapLibre exceptions (`Style is not done loading`, `Cannot style non-existing layer`) on the Advanced docs page corrupted Svelte 5's reactive graph, preventing SvelteKit's client-side router from completing page transitions — sidebar nav clicks changed the URL but never swapped the page content
- Extracted `LayerMarkersExample` map setup into a proper child component (`LayerMarkersContent`) using `$effect` lifecycle with `map.isStyleLoaded()` guard
- Added `isStyleLoaded` check + `style.load` event fallback in `CustomLayerContent` and layer existence checks in `toggleLayer()`

Closes #2
Closes #3
Closes #4

## Test plan
- [ ] Navigate to Advanced docs page — no console errors
- [ ] Click sidebar links from Advanced page — pages load correctly
- [ ] Verify "Markers via Layers" example shows blue circle markers
- [ ] Verify "Show Parks" toggle displays/hides park layers
- [ ] Navigate across all docs pages via sidebar without getting stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Deferred map layer initialization to ensure layers load only after the map style is ready.
  * Extracted marker rendering into a reusable component for cleaner interactive marker behavior.
  * Added defensive checks when toggling layer visibility to avoid errors.

* **Bug Fixes**
  * Navigation links updated to correctly respect the app base path, fixing link resolution across the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->